### PR TITLE
Added Fully-Connected Per-Channel optimisations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ if(CONFIG_IDF_TARGET_ESP32S3)
         "src/convolution/esp_nn_depthwise_conv_s16_mult4_esp32s3.S"
         "src/convolution/esp_nn_depthwise_conv_s16_mult8_esp32s3.S"
         "src/fully_connected/esp_nn_fully_connected_s8_esp32s3.S"
+        "src/fully_connected/esp_nn_fully_connected_per_ch_s8_esp32s3.S"
         "src/pooling/esp_nn_max_pool_s8_esp32s3.S"
         "src/pooling/esp_nn_avg_pool_s8_esp32s3.S")
 endif()

--- a/include/esp_nn_ansi_c.h
+++ b/include/esp_nn_ansi_c.h
@@ -41,6 +41,7 @@
 #define esp_nn_max_pool_s8 esp_nn_max_pool_s8_ansi
 
 #define esp_nn_fully_connected_s8 esp_nn_fully_connected_s8_ansi
+#define esp_nn_fully_connected_per_ch_s8 esp_nn_fully_connected_per_ch_s8_ansi
 
 #define esp_nn_get_softmax_scratch_size esp_nn_get_softmax_scratch_size_ansi
 #define esp_nn_set_softmax_scratch_buf esp_nn_set_softmax_scratch_buf_ansi

--- a/include/esp_nn_ansi_headers.h
+++ b/include/esp_nn_ansi_headers.h
@@ -200,6 +200,27 @@ void esp_nn_fully_connected_s8_ansi(const int8_t *input_data,
                                     const int32_t activation_max);
 
 /**
+ * @brief       fully connected
+ *
+ * @note        inputs type: int8_t, output: int8_t
+ *              input offsets: although int32_t, they are contained in 8 bits [-128, 127]
+ *              out_mult, out_shift: int32_t* containing per-channel data
+ */
+void esp_nn_fully_connected_per_ch_s8_ansi(const int8_t *input_data,
+                                    const int32_t input_offset,
+                                    const uint16_t row_len,
+                                    const int8_t *filter_data,
+                                    const int32_t filter_offset,
+                                    const int32_t *bias,
+                                    int8_t *out_data,
+                                    const uint16_t out_channels,
+                                    const int32_t out_offset,
+                                    const int32_t* out_shift,
+                                    const int32_t* out_mult,
+                                    const int32_t activation_min,
+                                    const int32_t activation_max);
+
+/**
  * @brief   Get scratch buffer size needed by softmax function
  *
  * @param   width

--- a/include/esp_nn_esp32p4.h
+++ b/include/esp_nn_esp32p4.h
@@ -61,6 +61,7 @@ void esp_nn_set_conv_scratch_buf_esp32p4(const void *buf);
 #define esp_nn_max_pool_s8 esp_nn_max_pool_s8_ansi
 
 #define esp_nn_fully_connected_s8 esp_nn_fully_connected_s8_ansi
+#define esp_nn_fully_connected_per_ch_s8 esp_nn_fully_connected_per_ch_s8_ansi
 
 #define esp_nn_get_softmax_scratch_size esp_nn_get_softmax_scratch_size_opt
 #define esp_nn_set_softmax_scratch_buf esp_nn_set_softmax_scratch_buf_opt

--- a/include/esp_nn_esp32s3.h
+++ b/include/esp_nn_esp32s3.h
@@ -198,6 +198,30 @@ void esp_nn_fully_connected_s8_esp32s3(const int8_t *input_data,
                                        const int32_t activation_max);
 
 /**
+ * @brief       fully connected - per channel
+ *
+ * @note        inputs type: int8_t, output: int8_t
+ *              input offsets: although int32_t, they are contained in 8 bits [-128, 127]
+ *              out_mult, out_shift: int32_t* containing per-channel data
+ *
+ *              Current version works only on aligned input.
+ *              row_len and channels should both be multiple of 8.
+ */
+void esp_nn_fully_connected_per_ch_s8_esp32s3(const int8_t *input_data,
+                                       const int32_t input_offset,
+                                       const uint16_t row_len,
+                                       const int8_t *filter_data,
+                                       const int32_t filter_offset,
+                                       const int32_t *bias,
+                                       int8_t *out_data,
+                                       const uint16_t out_channels,
+                                       const int32_t out_offset,
+                                       const int32_t* out_shift,
+                                       const int32_t* out_mult,
+                                       const int32_t activation_min,
+                                       const int32_t activation_max);
+
+/**
  * @brief       relu6
  *
  * @note        inout: int8_t
@@ -225,6 +249,7 @@ void esp_nn_relu6_s8_esp32s3(int8_t *data, uint16_t size);
 #define esp_nn_max_pool_s8 esp_nn_max_pool_s8_esp32s3
 
 #define esp_nn_fully_connected_s8 esp_nn_fully_connected_s8_esp32s3
+#define esp_nn_fully_connected_per_ch_s8 esp_nn_fully_connected_per_ch_s8_esp32s3
 
 #define esp_nn_get_softmax_scratch_size esp_nn_get_softmax_scratch_size_opt
 #define esp_nn_set_softmax_scratch_buf esp_nn_set_softmax_scratch_buf_opt

--- a/include/esp_nn_generic_opt.h
+++ b/include/esp_nn_generic_opt.h
@@ -41,6 +41,7 @@
 #define esp_nn_max_pool_s8 esp_nn_max_pool_s8_ansi
 
 #define esp_nn_fully_connected_s8 esp_nn_fully_connected_s8_ansi
+#define esp_nn_fully_connected_per_ch_s8 esp_nn_fully_connected_per_ch_s8_ansi
 
 #define esp_nn_get_softmax_scratch_size esp_nn_get_softmax_scratch_size_opt
 #define esp_nn_set_softmax_scratch_buf esp_nn_set_softmax_scratch_buf_opt

--- a/src/fully_connected/esp_nn_fully_connected_ansi.c
+++ b/src/fully_connected/esp_nn_fully_connected_ansi.c
@@ -48,3 +48,36 @@ void esp_nn_fully_connected_s8_ansi(const int8_t *input_data,
         out_data[out_c] = (int8_t) result;
     }
 }
+
+void esp_nn_fully_connected_per_ch_s8_ansi(const int8_t *input_data,
+                                    const int32_t input_offset,
+                                    const uint16_t row_len,
+                                    const int8_t *filter_data,
+                                    const int32_t filter_offset,
+                                    const int32_t *bias,
+                                    int8_t *out_data,
+                                    const uint16_t out_channels,
+                                    const int32_t out_offset,
+                                    const int32_t* out_shift,
+                                    const int32_t* out_mult,
+                                    const int32_t activation_min,
+                                    const int32_t activation_max)
+{
+    for (int32_t out_c = 0; out_c < out_channels; ++out_c) {
+        int32_t result = 0;
+        for (int32_t data_idx = 0; data_idx < row_len; data_idx++) {
+            int32_t filter_index = row_len * out_c + data_idx;
+            int32_t input_val = input_data[data_idx];
+            int32_t filter_val = filter_data[filter_index];
+            result += (filter_val + filter_offset) * (input_val + input_offset);
+        }
+        if (bias) {
+            result += bias[out_c];
+        }
+        result = esp_nn_multiply_by_quantized_mult(result, out_mult[out_c], out_shift[out_c]);
+        result += out_offset;
+        result = max(result, activation_min);
+        result = min(result, activation_max);
+        out_data[out_c] = (int8_t) result;
+    }
+}

--- a/src/fully_connected/esp_nn_fully_connected_per_ch_s8_esp32s3.S
+++ b/src/fully_connected/esp_nn_fully_connected_per_ch_s8_esp32s3.S
@@ -1,0 +1,222 @@
+//
+// SPDX-FileCopyrightText: 2025 Espressif Systems (Shanghai) CO LTD
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+    .text
+    .align  4
+    .literal_position
+    .literal    .LC3_26_101, 1073741824 // nudge (1 << 30)
+
+    # Program Unit: esp_nn_fully_connected_per_ch_s8_esp32s3
+    .type   esp_nn_fully_connected_per_ch_s8_esp32s3, @function
+    .align   4
+    .global esp_nn_fully_connected_per_ch_s8_esp32s3
+
+// a2: input_data
+// a3: input_offset
+// a4: row_len
+// a5: filter_data
+// a6: filter_offset
+// a7: bias
+// on stack: out_data
+// on stack: out_channels
+// on stack: out_offset
+// on stack: out_shift
+// on stack: out_mult
+// on stack: activation_min
+// on stack: activation_max
+
+esp_nn_fully_connected_per_ch_s8_esp32s3:  # 0x4
+    # qacc_scratch = 0
+    // 40, filter_offset
+    // 44, input_offset
+    # gra_spill_temp_7 = 48
+    # gra_spill_temp_2 = 60
+    # gra_spill_temp_3 = 64
+    # gra_spill_temp_4 = 68
+    # gra_spill_temp_5 = 72
+    # gra_spill_temp_6 = 76
+    # gra_spill_temp_8 = 80
+    # gra_spill_temp_9 = 84
+
+    entry   a1,112                      #
+    s32i.n  a5,a1,60                # [0]  gra_spill_temp_2, filter_data
+    s32i    a7,a1,48                    # [1]  gra_spill_temp_7, bias
+    s32i    a6,a1,40                    # [2]  id:252 filter_offset+0x0
+    s32i    a3,a1,44                    # [3]  id:251 input_offset+0x0
+    mov.n   a13,a2                      # [5]
+    mov.n   a12,a4                      # [6]
+
+ // out_channel loop
+    l16ui       a2,a1,116                   # [7]  id:255 out_channels+0x0
+    addi        a4,a1,40                # [8]
+    addi        a8,a1,44                # [9]
+    ee.vldbc.16 q5,a8               # [10]  id:253 input_offset
+    ee.vldbc.16 q6,a4               # [12]  id:254 filter_offset
+    beqz.n      a2,.Lt_0_7938           # [13]
+
+    ee.zero.q   q7                      # [0]
+    srai        a11,a12,3                   # [2]
+    l32i        a8,a1,112                   # [6]  id:259 out_data+0x0
+    addi        a9,a12,-7                   # [7]
+    s32i        a9,a1,76                    # [8]  gra_spill_temp_6
+    s32i        a8,a1,72                    # [9]  gra_spill_temp_5
+    s32i        a11,a1,64                   # [14]  gra_spill_temp_3
+    slli        a11,a11,3                   # [16]
+    s32i        a11,a1,68                   # [18]  gra_spill_temp_4
+    movi.n      a15,0                   # [17]
+    mov.n       a14,a7                      # [15]
+    mov.n       a11,a5                      # [31]
+    l32i        a10,a1,124  # out_shift
+    l32i        a2,a1,128  # out_mult
+    s32i        a10,a1,80                   # gra_spill_temp_8
+    s32i        a2,a1,84                   # gra_spill_temp_9
+    movi.n      a10,0                   # [32]
+    mov.n       a2,a11                      # [33]
+
+.Lt_0_8450: # 0x12b
+    l32i            a9,a1,76                    # [2]  gra_spill_temp_6
+    extui           a5,a11,0,3                  # [34]
+    ee.zero.accx
+    slli            a5,a5,1                     # [3]
+    bgei            a9,0,.LBB6_esp_nn_fully_connected_per_ch_s8_esp32s3            # [9]
+
+    mov.n           a5,a10                      # [6]
+    movi.n  a2,0                    # [0]
+    j       .Lt_0_8706                      # [1]
+
+.LBB6_esp_nn_fully_connected_per_ch_s8_esp32s3:    # 0x147
+    wur.sar_byte    a5                  # [5]
+    ee.vld.l.64.ip  q4,a2,8         # [4]  id:267
+    l32i            a4,a1,64                    # [0]  gra_spill_temp_3
+    mov.n           a3,a13                      # [1]
+    addx8           a5,a4,a10                   # [2]
+    ee.vcmp.lt.s8   q2,q4,q7            # [7]
+    ee.vzip.8       q4,q2                   # [8]
+    loopgtz a4,.LBB45_esp_nn_fully_connected_per_ch_s8_esp32s3     # [3]
+
+    ee.vld.l.64.ip      q0,a2,8         # [0*II+0]  id:268
+    ee.vld.l.64.ip      q1,a3,8         # [0*II+1]  id:270
+    ee.vcmp.lt.s8       q2,q0,q7            # [0*II+2]
+    ee.vcmp.lt.s8       q3,q1,q7            # [0*II+3]
+    ee.vzip.8           q0,q2                   # [0*II+4]
+    ee.vzip.8           q1,q3                   # [0*II+5]
+    ee.vadds.s16        q1,q1,q5            # [0*II+6]
+    ee.src.q.qup        q2,q4,q0            # [0*II+7]
+    ee.vadds.s16        q2,q2,q6            # [0*II+8]
+    ee.vmulas.s16.accx  q1,q2       # [0*II+9]
+
+.LBB45_esp_nn_fully_connected_per_ch_s8_esp32s3:   # 0x170
+    l32i    a2,a1,68                    # [0]  gra_spill_temp_4
+
+.Lt_0_8706: # 0x173
+	movi a9, 0
+	ee.srs.accx  a6, a9, 0
+
+    bge             a2,a12,.Lt_0_9730           # [38]
+
+// prepare remaining loop
+    l32i    a8,a1,44                    # [0]  id:251 input_offset+0x0
+    l32i    a7,a1,40                    # [1]  id:252 filter_offset+0x0
+    sub     a3,a12,a2                   # [2]
+    l32i.n  a4,a1,60                # [3]  gra_spill_temp_2
+    add.n   a2,a2,a13                   # [4]
+    add.n   a4,a4,a5                    # [5]
+    loopgtz a3,.LBB60_esp_nn_fully_connected_per_ch_s8_esp32s3     # [6]
+
+// remaining c loop
+    l8ui    a3,a2,0                     # [0*II+0]  id:299
+    l8ui    a5,a4,0                     # [0*II+1]  id:300
+    sext    a3,a3,7                     # [0*II+2]
+    sext    a5,a5,7                     # [0*II+3]
+    add.n   a5,a5,a7                    # [0*II+5]
+    add.n   a3,a3,a8                    # [0*II+6]
+    mull    a3,a3,a5                    # [0*II+7]
+    addi.n  a2,a2,1                 # [0*II+8]
+    addi.n  a4,a4,1                 # [0*II+4]
+    add.n   a6,a6,a3                    # [0*II+9]
+
+.LBB60_esp_nn_fully_connected_per_ch_s8_esp32s3:   # 0x20f
+
+// add bias
+.Lt_0_9730: # 0x20f
+    l32i    a8,a1,48                    # [0]  gra_spill_temp_7, bias
+    beqz.n  a8,.Lt_0_10754          # [2], skip_bias
+
+    l32i.n  a9,a14,0                # [0]  id:301
+    add.n   a6,a6,a9                    # [2]
+
+// apply quantization
+.Lt_0_10754:    # 0x218
+    movi        a4,0
+    l32i        a5,a1,80                  # [25]  id:256 gra_spill_temp_8, out_shift+0x0
+    l32i        a5,a5,0
+    max         a2,a5,a4                 // left_shift
+    sub         a5,a2,a5                 // right_shift
+
+    ssl     a2                          # [3]
+    sll     a6,a6                       # [5] // x * (1 << left_shift)
+
+    l32i    a4,a1,84                   # [2]  gra_spill_temp_9 //out_mult
+    l32r    a3,.LC3_26_101              # [0]
+
+    add.n   a10,a10,a12                 # [0]
+    addi.n  a14,a14,4               # [1]
+
+    l32i    a4,a4,0
+    add.n   a11,a11,a12                 # [6]
+
+// multiply add nudge and pick high32
+    ssai    31
+    mulsh   a7,a4,a6                    # [4]
+    mull    a4,a4,a6                    # [5]
+
+    mov.n   a2,a11                      # [27]
+    add     a4,a4,a3
+    saltu   a8,a4,a3
+    add.n   a7,a7,a8
+    src     a3,a7,a4
+
+// divide_by_power_of2_step
+    blti    a5,1,.skip_divide_by2
+    movi.n  a8,1                    # [28]
+    addi    a4,a5,-1
+    ssl     a4          // load left_shift
+    sll     a8,a8       // to_add factor ( 1 << (exponent - 1))
+    extui   a6,a3,31,1                  # [33]
+    sub     a8,a8,a6        // modified to_add factor ( 1 << (exponent - 1) - (val < 0))
+    add     a3,a3,a8    // val + to_add
+    ssr     a5                          # [29] //load right_shift
+    sra     a3,a3                       # [31]
+.skip_divide_by2:
+
+    l32i    a8,a1,120                   # [41]  out_offset
+    l32i    a7,a1,132                   # [44] // activation_min
+    l32i    a4,a1,136                   # [45] // activation_max
+
+    add.n   a8,a8,a3                    # [46] // add out_offset
+    l32i    a6,a1,72                    # [47]  gra_spill_temp_5
+    l32i.n  a3,a1,116                   # [48]  out_channels
+    max     a7,a7,a8                    # [49]
+    add.n   a6,a15,a6                   # [50]
+    min     a4,a4,a7                    # [51]
+    addi.n  a15,a15,1               # [52]
+
+    l32i        a7,a1,84                # gra_spill_temp_9
+    l32i        a8,a1,80                # gra_spill_temp_8
+
+    s8i     a4,a6,0                     # store output
+
+    addi.n      a7,a7,4                 # increment mult pointer
+    addi.n      a8,a8,4                 # increment mult pointer
+
+    s32i        a7,a1,84                # gra_spill_temp_9
+    s32i        a8,a1,80                # gra_spill_temp_8
+
+    bne     a3,a15,.Lt_0_8450               # [55]
+
+.Lt_0_7938: # 0x25c
+    retw.n                          # [0]
+
+    .size   esp_nn_fully_connected_per_ch_s8_esp32s3, . - esp_nn_fully_connected_per_ch_s8_esp32s3

--- a/test_app/main/main.c
+++ b/test_app/main/main.c
@@ -71,6 +71,7 @@ void app_main()
     esp_nn_max_pool_s8_test();
     printf("max_pool, c %"PRIu32" opt %"PRIu32"\n", total_c, total_opt);
     esp_nn_fully_connected_s8_test();
+    esp_nn_fully_connected_per_ch_s8_test();
     esp_nn_softmax_s8_test();
     printf("softmax, c %"PRIu32" opt %"PRIu32"\n", total_c, total_opt);
     ESP_LOGI(TAG, "s8 tests done!\n");

--- a/tests/include/test_functions.h
+++ b/tests/include/test_functions.h
@@ -24,6 +24,7 @@ void esp_nn_avg_pool_s8_test();
 void esp_nn_max_pool_s8_test();
 
 void esp_nn_fully_connected_s8_test();
+void esp_nn_fully_connected_per_ch_s8_test();
 
 void esp_nn_relu6_s8_test();
 

--- a/tests/include/test_utils.h
+++ b/tests/include/test_utils.h
@@ -92,3 +92,18 @@ uint32_t profile_opt_end();
     }                                                   \
     printf("\n");                                       \
 })
+
+#if CONFIG_IDF_CMAKE
+#if ((CONFIG_SPIRAM || CONFIG_SPIRAM_SUPPORT || CONFIG_ESP32S3_SPIRAM_SUPPORT) && \
+        (CONFIG_SPIRAM_USE_CAPS_ALLOC || CONFIG_SPIRAM_USE_MALLOC))
+#define IDF_HEAP_CAPS 1
+#endif
+#endif
+
+#if IDF_HEAP_CAPS
+#include "esp_heap_caps.h"
+#define ESP_NN_TEST_ALLOC(SIZE) heap_caps_malloc(SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT)
+#else
+#include <malloc.h>
+#define ESP_NN_TEST_ALLOC(SIZE) malloc(SIZE)
+#endif

--- a/tests/src/basic_math_test.c
+++ b/tests/src/basic_math_test.c
@@ -15,16 +15,6 @@
 #include <esp_nn.h>
 #include "test_utils.h"
 
-#if CONFIG_IDF_CMAKE
-#if (CONFIG_SPIRAM_SUPPORT && (CONFIG_SPIRAM_USE_CAPS_ALLOC || CONFIG_SPIRAM_USE_MALLOC))
-#define IDF_HEAP_CAPS 1
-#endif
-
-#if IDF_HEAP_CAPS
-#include "esp_heap_caps.h"
-#endif
-#endif
-
 const int8_t test_add_in1[] = {
        13,   26,  -26,   26,  -13,   13,  -13,   13,  -13,   13,  -13,   13,  -26,  -51,  -26,  -51,
       -26,  -39,  -26,  -39,  -39,  -39,  -26,  -51,  -13,  -13,  -13,  -13,  -26,  -13,  -13,  -13,
@@ -159,17 +149,12 @@ void esp_nn_add_elementwise_s8_test()
             output_shift = -8 + rand() % 4;
             left_shift = rand() % 15;
         }
-#if IDF_HEAP_CAPS
-        input1_orig = (int8_t *) heap_caps_malloc(size + 16, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-        input2_orig = (int8_t *) heap_caps_malloc(size + 16, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-        out_c_orig = (int8_t *) heap_caps_malloc(size + 16, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-        out_opt_orig = (int8_t *) heap_caps_malloc(size + 16, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-#else
-        input1_orig = malloc(size + 16);
-        input2_orig = malloc(size + 16);
-        out_c_orig = malloc(size + 16);
-        out_opt_orig = malloc(size + 16);
-#endif
+
+        input1_orig = (int8_t *) ESP_NN_TEST_ALLOC(size + 16);
+        input2_orig = (int8_t *) ESP_NN_TEST_ALLOC(size + 16);
+        out_c_orig = (int8_t *) ESP_NN_TEST_ALLOC(size + 16);
+        out_opt_orig = (int8_t *) ESP_NN_TEST_ALLOC(size + 16);
+
         if (input1_orig == NULL || input2_orig == NULL ||
                 out_c_orig == NULL || out_opt_orig == NULL) {
             printf(ANSI_COLOR_RED"%s error allocating buffers\n"ANSI_COLOR_RESET, __FUNCTION__);
@@ -314,17 +299,11 @@ void esp_nn_mul_elementwise_s8_test()
             size = 4 + rand() % 64;
         }
 
-#if IDF_HEAP_CAPS
-        input1_orig = (int8_t *) heap_caps_malloc(size + 16, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-        input2_orig = (int8_t *) heap_caps_malloc(size + 16, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-        out_c_orig = (int8_t *) heap_caps_malloc(size + 16, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-        out_opt_orig = (int8_t *) heap_caps_malloc(size + 16, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-#else
-        input1_orig = malloc(size + 16);
-        input2_orig = malloc(size + 16);
-        out_c_orig = malloc(size + 16);
-        out_opt_orig = malloc(size + 16);
-#endif
+        input1_orig = (int8_t *) ESP_NN_TEST_ALLOC(size + 16);
+        input2_orig = (int8_t *) ESP_NN_TEST_ALLOC(size + 16);
+        out_c_orig = (int8_t *) ESP_NN_TEST_ALLOC(size + 16);
+        out_opt_orig = (int8_t *) ESP_NN_TEST_ALLOC(size + 16);
+
         if (input1_orig == NULL || input2_orig == NULL ||
                 out_c_orig == NULL || out_opt_orig == NULL) {
             printf(ANSI_COLOR_RED"%s error allocating buffers\n"ANSI_COLOR_RESET, __FUNCTION__);

--- a/tests/src/fully_connected_test.c
+++ b/tests/src/fully_connected_test.c
@@ -145,105 +145,69 @@ void esp_nn_fully_connected_per_ch_s8_test()
     int32_t input_offset = 0;
     int32_t filter_offset = 0;
     int32_t out_offset = 7;
-    int32_t* out_mult;
-    int32_t* out_shift;
+
+    int32_t* out_mult = NULL;
+    int32_t* out_shift = NULL;
 
     printf("\n######## Running %s ##########\n", __FUNCTION__);
     for (int itr = 0;  itr < 15; itr++) {
+        int32_t out_shift_val = 0;
         switch (itr) {
         case 0:
-            out_mult = malloc(out_channels * sizeof(int32_t));
-            out_shift = malloc(out_channels * sizeof(int32_t));
-            for (int i = 0; i < out_channels; i++) {
-                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
-                out_shift[i] = -10;
-            }
+            out_shift_val = -10;
             break;
         case 1:
-            out_mult = malloc(out_channels * sizeof(int32_t));
-            out_shift = malloc(out_channels * sizeof(int32_t));
-            for (int i = 0; i < out_channels; i++) {
-                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
-                out_shift[i] = SHIFT_MIN;
-            }
+            out_shift_val = SHIFT_MIN;
             break;
         case 2:
-            out_mult = malloc(out_channels * sizeof(int32_t));
-            out_shift = malloc(out_channels * sizeof(int32_t));
-            for (int i = 0; i < out_channels; i++) {
-                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
-                out_shift[i] = SHIFT_MAX;
-            }
+            out_shift_val = SHIFT_MAX;
             break;
         case 3:
-            out_mult = malloc(out_channels * sizeof(int32_t));
-            out_shift = malloc(out_channels * sizeof(int32_t));
-            for (int i = 0; i < out_channels; i++) {
-                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
-                out_shift[i] = 0;
-            }
+            out_shift_val = 0;
             break;
         case 4:
             row_len = 1;
             out_channels = 16;
-            out_mult = malloc(out_channels * sizeof(int32_t));
-            out_shift = malloc(out_channels * sizeof(int32_t));
-            for (int i = 0; i < out_channels; i++) {
-                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
-                out_shift[i] = -10 + rand() % 5;
-            }
             break;
         case 5:
             row_len = 16;
             out_channels = 8;
-            out_mult = malloc(out_channels * sizeof(int32_t));
-            out_shift = malloc(out_channels * sizeof(int32_t));
-            for (int i = 0; i < out_channels; i++) {
-                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
-                out_shift[i] = -10 + rand() % 5;
-            }
             break;
         case 6:
             row_len = 8;
             out_channels = 8;
-            out_mult = malloc(out_channels * sizeof(int32_t));
-            out_shift = malloc(out_channels * sizeof(int32_t));
-            for (int i = 0; i < out_channels; i++) {
-                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
-                out_shift[i] = -10 + rand() % 5;
-            }
             break;
         case 7:
             row_len = 8;
             out_channels = 15;
-            out_mult = malloc(out_channels * sizeof(int32_t));
-            out_shift = malloc(out_channels * sizeof(int32_t));
-            for (int i = 0; i < out_channels; i++) {
-                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
-                out_shift[i] = -10 + rand() % 5;
-            }
             break;
         case 8:
             row_len = 8;
             out_channels = 1;
-            out_mult = malloc(out_channels * sizeof(int32_t));
-            out_shift = malloc(out_channels * sizeof(int32_t));
-            for (int i = 0; i < out_channels; i++) {
-                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
-                out_shift[i] = -10 + rand() % 5;
-            }
             break;
         default:
             row_len = rand() % 7 + 1;
             out_channels = 8;
-            out_mult = malloc(out_channels * sizeof(int32_t));
-            out_shift = malloc(out_channels * sizeof(int32_t));
-            for (int i = 0; i < out_channels; i++) {
-                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
-                out_shift[i] = -10 + rand() % 5;
-            }
             break;
         }
+
+        out_mult = ESP_NN_TEST_ALLOC(out_channels * sizeof(int32_t));
+        out_shift = ESP_NN_TEST_ALLOC(out_channels * sizeof(int32_t));
+
+        if (out_shift == NULL || out_mult == NULL) {
+            printf(ANSI_COLOR_RED"out_shift/out_mult allocations failed\n"ANSI_COLOR_RESET);
+            goto fully_connected_per_ch_cleanup;
+        }
+
+        for (int i = 0; i < out_channels; i++) {
+            out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
+            if (i < 4) {
+                out_shift[i] = out_shift_val;
+            } else {
+                out_shift[i] = -10 + rand() % 5;
+            }
+        }
+
         /* Generate input and filter data */
         for (int i = 0; i < row_len; ++i) {
             input[i] = rand() % 256 - 128;
@@ -251,10 +215,7 @@ void esp_nn_fully_connected_per_ch_s8_test()
         for (int i = 0; i < row_len * out_channels; ++i) {
             filter_data[i] = rand() % 256 - 128;
         }
-
-        printf("%d, %ld\n", input[0], input_offset);
-        printf("%d, %ld\n", filter_data[0], filter_offset);
-
+        
         /* enable profiler */
         profile_c_start();
 
@@ -298,13 +259,18 @@ void esp_nn_fully_connected_per_ch_s8_test()
             }
             printf("\n");
 #endif
-
-            free(out_shift);
-            free(out_mult);
-            return;
+            goto fully_connected_per_ch_cleanup;
         }
         printf(ANSI_COLOR_GREEN"[%3d] passed [row_len %"PRIu16", out_ch %"PRIu16"]"ANSI_COLOR_RESET,
                itr, row_len, out_channels);
         printf("\tcycles: c %8"PRIu32", opt %8"PRIu32"\n", total_c, total_opt);
+    
+    fully_connected_per_ch_cleanup:
+        if (out_shift) {
+            free(out_shift);
+        }
+        if (out_mult) {
+            free(out_mult);
+        }
     }
 }

--- a/tests/src/fully_connected_test.c
+++ b/tests/src/fully_connected_test.c
@@ -129,3 +129,182 @@ void esp_nn_fully_connected_s8_test()
         printf("\tcycles: c %8"PRIu32", opt %8"PRIu32"\n", total_c, total_opt);
     }
 }
+
+void esp_nn_fully_connected_per_ch_s8_test()
+{
+    uint32_t total_c = 0, total_opt = 0;
+    /* prepare data */
+    uint16_t row_len = 256 + 8 + 7; /* odd len to test unaligned+left-over */
+    const int32_t max_out_ch = 16;
+    uint16_t out_channels = 3;
+    int8_t input[row_len];
+    int8_t filter_data[row_len * max_out_ch];
+    int8_t output_c[max_out_ch], output_opt[max_out_ch];
+    int32_t activation_min = -128;
+    int32_t activation_max = 127;
+    int32_t input_offset = 0;
+    int32_t filter_offset = 0;
+    int32_t out_offset = 7;
+    int32_t* out_mult;
+    int32_t* out_shift;
+
+    printf("\n######## Running %s ##########\n", __FUNCTION__);
+    for (int itr = 0;  itr < 15; itr++) {
+        switch (itr) {
+        case 0:
+            out_mult = malloc(out_channels * sizeof(int32_t));
+            out_shift = malloc(out_channels * sizeof(int32_t));
+            for (int i = 0; i < out_channels; i++) {
+                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
+                out_shift[i] = -10;
+            }
+            break;
+        case 1:
+            out_mult = malloc(out_channels * sizeof(int32_t));
+            out_shift = malloc(out_channels * sizeof(int32_t));
+            for (int i = 0; i < out_channels; i++) {
+                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
+                out_shift[i] = SHIFT_MIN;
+            }
+            break;
+        case 2:
+            out_mult = malloc(out_channels * sizeof(int32_t));
+            out_shift = malloc(out_channels * sizeof(int32_t));
+            for (int i = 0; i < out_channels; i++) {
+                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
+                out_shift[i] = SHIFT_MAX;
+            }
+            break;
+        case 3:
+            out_mult = malloc(out_channels * sizeof(int32_t));
+            out_shift = malloc(out_channels * sizeof(int32_t));
+            for (int i = 0; i < out_channels; i++) {
+                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
+                out_shift[i] = 0;
+            }
+            break;
+        case 4:
+            row_len = 1;
+            out_channels = 16;
+            out_mult = malloc(out_channels * sizeof(int32_t));
+            out_shift = malloc(out_channels * sizeof(int32_t));
+            for (int i = 0; i < out_channels; i++) {
+                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
+                out_shift[i] = -10 + rand() % 5;
+            }
+            break;
+        case 5:
+            row_len = 16;
+            out_channels = 8;
+            out_mult = malloc(out_channels * sizeof(int32_t));
+            out_shift = malloc(out_channels * sizeof(int32_t));
+            for (int i = 0; i < out_channels; i++) {
+                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
+                out_shift[i] = -10 + rand() % 5;
+            }
+            break;
+        case 6:
+            row_len = 8;
+            out_channels = 8;
+            out_mult = malloc(out_channels * sizeof(int32_t));
+            out_shift = malloc(out_channels * sizeof(int32_t));
+            for (int i = 0; i < out_channels; i++) {
+                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
+                out_shift[i] = -10 + rand() % 5;
+            }
+            break;
+        case 7:
+            row_len = 8;
+            out_channels = 15;
+            out_mult = malloc(out_channels * sizeof(int32_t));
+            out_shift = malloc(out_channels * sizeof(int32_t));
+            for (int i = 0; i < out_channels; i++) {
+                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
+                out_shift[i] = -10 + rand() % 5;
+            }
+            break;
+        case 8:
+            row_len = 8;
+            out_channels = 1;
+            out_mult = malloc(out_channels * sizeof(int32_t));
+            out_shift = malloc(out_channels * sizeof(int32_t));
+            for (int i = 0; i < out_channels; i++) {
+                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
+                out_shift[i] = -10 + rand() % 5;
+            }
+            break;
+        default:
+            row_len = rand() % 7 + 1;
+            out_channels = 8;
+            out_mult = malloc(out_channels * sizeof(int32_t));
+            out_shift = malloc(out_channels * sizeof(int32_t));
+            for (int i = 0; i < out_channels; i++) {
+                out_mult[i] = INT32_MAX / row_len + rand() % INT16_MAX;
+                out_shift[i] = -10 + rand() % 5;
+            }
+            break;
+        }
+        /* Generate input and filter data */
+        for (int i = 0; i < row_len; ++i) {
+            input[i] = rand() % 256 - 128;
+        }
+        for (int i = 0; i < row_len * out_channels; ++i) {
+            filter_data[i] = rand() % 256 - 128;
+        }
+
+        printf("%d, %ld\n", input[0], input_offset);
+        printf("%d, %ld\n", filter_data[0], filter_offset);
+
+        /* enable profiler */
+        profile_c_start();
+
+        /* C function */
+        esp_nn_fully_connected_per_ch_s8_ansi(input, input_offset, row_len, filter_data, filter_offset,
+                                    NULL, output_c, out_channels, out_offset, out_shift, out_mult,
+                                    activation_min, activation_max);
+
+        total_c = profile_c_end();
+        profile_opt_start();
+
+        /* Optimized function */
+        esp_nn_fully_connected_per_ch_s8(input, input_offset, row_len, filter_data, filter_offset,
+                                NULL, output_opt, out_channels, out_offset, out_shift, out_mult,
+                                activation_min, activation_max);
+
+        /* disable profiler */
+        total_opt = profile_opt_end();
+
+        bool ret = CHECK_EQUAL(output_c, output_opt, out_channels);
+        if (ret == false) {
+            printf(ANSI_COLOR_RED"[%3d] failed\n"ANSI_COLOR_RESET, itr);
+#if 0
+            printf("Output: \n");
+            PRINT_ARRAY_HEX(output_opt, out_channels, 1);
+            printf("Expected: \n");
+            PRINT_ARRAY_HEX(output_c, out_channels, 1);
+            printf("Input:\n");
+            PRINT_ARRAY_HEX(input, row_len, 1);
+            printf("Filter data:\n");
+            PRINT_ARRAY_HEX(filter_data, row_len, out_channels);
+
+            printf("Out shift: ");
+            for (int i = 0; i < out_channels; i++) {
+                printf("%d, ", out_shift[i]);
+            }
+
+            printf("\nOut mult: ");
+            for (int i = 0; i < out_channels; i++) {
+                printf("%d, ", out_mult[i]);
+            }
+            printf("\n");
+#endif
+
+            free(out_shift);
+            free(out_mult);
+            return;
+        }
+        printf(ANSI_COLOR_GREEN"[%3d] passed [row_len %"PRIu16", out_ch %"PRIu16"]"ANSI_COLOR_RESET,
+               itr, row_len, out_channels);
+        printf("\tcycles: c %8"PRIu32", opt %8"PRIu32"\n", total_c, total_opt);
+    }
+}


### PR DESCRIPTION
- Added both Assembly and ANSI-C methods for implementing Fully-Connected Per-Channel
- Have written a Unit-Test to test the same (15/15 cases passing)

## Description
ESP-NN currently doesn't have an optimisation for Fully-Connected processnig for Per-Channel data.
In this operation, `output_shift` and `output_multiplier` are not the same for all channels.

This PR adds the said optimisations, both the Assembly and ANSI-C versions.

## Testing
A unit test has been added to test the same. Following are the results:-

<img width="761" alt="image" src="https://github.com/user-attachments/assets/f5c4bfe0-f8c1-4662-a117-a9742f7f6628" />

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
