### PR TITLE
fix(depthwise): size scratch for asymmetric padding on esp32s3

### DIFF
--- a/src/convolution/esp_nn_depthwise_conv_s8_esp32s3.c
+++ b/src/convolution/esp_nn_depthwise_conv_s8_esp32s3.c
@@ -368,7 +368,9 @@ int esp_nn_get_depthwise_conv_scratch_size_esp32s3(const data_dims_t *input_dims
 
     if ((ch_mult == 1) && (channels % 8 == 0)) {
         if(filter_wd == 3 && filter_ht == 3) {
-            if (channels % 16 == 0) {
+            /* symmetric padding only: same test the kernel dispatch makes */
+            if ((channels % 16 == 0) &&
+                (((pad_wd == 1) && (pad_ht == 1)) || ((pad_wd == 0) && (pad_ht == 0)))) {
                 if (pad_wd || pad_ht) {
                     pad_width = pad_wd * 2;
                     pad_height = pad_ht * 2;

--- a/tests/src/convolution_test.c
+++ b/tests/src/convolution_test.c
@@ -8,11 +8,16 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <malloc.h>
 #include <inttypes.h>
 
 #include <esp_nn.h>
 #include "test_utils.h"
+
+/* Scratch guard: sized to absorb an overflow, not just detect it */
+#define SCRATCH_GUARD_SZ    (16 * 1024)
+#define SCRATCH_GUARD_BYTE  0x5a
 
 void esp_nn_depthwise_conv_s8_test()
 {
@@ -32,9 +37,14 @@ void esp_nn_depthwise_conv_s8_test()
     uint16_t pad_wd, pad_ht, stride_wd, stride_ht;
 
     printf("\n######## Running %s ##########\n", __FUNCTION__);
-    // run for 18 iterations
-    for (int itr = 0; itr < 18; itr++) {
+    // run for 19 iterations
+    for (int itr = 0; itr < 19; itr++) {
         bool no_bias = false;
+        /* Explicit output dims (0 = derive from pad/stride below). Needed for
+         * TFLite-style asymmetric "SAME" padding where only the leading
+         * (top/left) padding is passed in and trailing padding is implicit. */
+        uint16_t force_out_wd = 0, force_out_ht = 0;
+
         /* prepare data */
         switch (itr) {
         case 0: // (ch_mult 1, (channels % 16) = 0), filter (3,3), pad (0,0)
@@ -194,6 +204,19 @@ void esp_nn_depthwise_conv_s8_test()
             stride_ht = 1;
             no_bias = true;
             break;
+        case 18: // asymmetric "SAME" padding as TFLite generates it (3x3, stride 2)
+            input_wd = 49;
+            input_ht = 20;
+            filter_ht = 3;
+            filter_wd = 3;
+            ch_mult = 1;
+            channels = 32;
+            pad_wd = 1;
+            pad_ht = 0;
+            stride_wd = 2;
+            stride_ht = 2;
+            force_out_ht = 10; /* SAME: ceil(20/2); derived VALID value would be 9 */
+            break;
         default:
             input_wd = 6;
             input_ht = 6;
@@ -218,6 +241,12 @@ void esp_nn_depthwise_conv_s8_test()
             out_ht = (input_ht + stride_ht - 1) / stride_ht;
         } else {
             out_ht = (input_ht + stride_ht - filter_ht) / stride_ht;
+        }
+        if (force_out_wd) {
+            out_wd = force_out_wd;
+        }
+        if (force_out_ht) {
+            out_ht = force_out_ht;
         }
 
         // if (itr == 9) {
@@ -275,14 +304,17 @@ void esp_nn_depthwise_conv_s8_test()
 
         int scratch_buf_size = esp_nn_get_depthwise_conv_scratch_size(&input_dims, &filter_dims,
                                                                       &output_dims, &conv_params);
+        int8_t *scratch_guard = NULL;
         if (scratch_buf_size > 0) {
-            scratch_buf = ESP_NN_TEST_ALLOC(scratch_buf_size + 16);
+            scratch_buf = ESP_NN_TEST_ALLOC(scratch_buf_size + 16 + SCRATCH_GUARD_SZ);
             if (scratch_buf == NULL) {
                 printf(ANSI_COLOR_RED"[%d] scratch_buf alloc failed size %d\n"ANSI_COLOR_RESET,
                        itr, scratch_buf_size);
                 goto dc_s8_cleanup;
             }
             int align_sz = 16 - (((int32_t) scratch_buf) & 0xf);
+            scratch_guard = (int8_t *) scratch_buf + align_sz + scratch_buf_size;
+            memset(scratch_guard, SCRATCH_GUARD_BYTE, SCRATCH_GUARD_SZ);
             esp_nn_set_depthwise_conv_scratch_buf(scratch_buf + align_sz);
         }
 
@@ -304,6 +336,22 @@ void esp_nn_depthwise_conv_s8_test()
 
         /* disable profiler */
         total_opt = profile_opt_end();
+
+        /* scan whole guard: extent, not just first hit */
+        int overflow = 0;
+        for (int i = 0; scratch_guard && i < SCRATCH_GUARD_SZ; i++) {
+            if (scratch_guard[i] != (int8_t) SCRATCH_GUARD_BYTE) {
+                overflow = i + 1;
+            }
+        }
+        if (overflow) {
+            printf(ANSI_COLOR_RED"[%3d] scratch overflow: wrote at least %d bytes past"
+                   " reported size %d [pad: (%d, %d), stride: (%d, %d), out: (%3d,%3d),"
+                   " ch %3d]\n"ANSI_COLOR_RESET,
+                   itr, overflow, scratch_buf_size, pad_wd, pad_ht,
+                   stride_wd, stride_ht, out_wd, out_ht, channels);
+            goto dc_s8_cleanup;
+        }
 
         bool ret = CHECK_EQUAL(out_data_c, out_data_opt, out_size);
         if (ret == false) {


### PR DESCRIPTION
## Description

`esp_nn_get_depthwise_conv_scratch_size_esp32s3` tests only `channels % 16 == 0`
and returns the s8-padded size, but the kernel takes that path only when padding
is symmetric. Anything else runs `channels >= 12`, which needs
`pad_right`/`pad_bottom` and a padded output buffer, so the kernel writes past the
buffer TFLM hands it — no crash, no error code, just wrong values.

TFLite stores the leading padding value, so a 3x3 stride-2 `SAME` convolution over
an even extent can arrive as e.g. (1,0). On a DS-CNN a 49x20x32 layer got 32944
bytes for 44912 written; across a sweep of 3x3 `SAME` shapes, 25,984 of 103,968
(25.0%) are under-allocated.

The fix matches the sizing condition to the kernel dispatch, so asymmetric padding
falls into the `channels >= 12` sizing branch, which over-estimates and is safe.
The kernel is untouched, so `Invoke` and the README benchmarks are unchanged.

One thing to note before merging: scratch consumption rises for asymmetric
padding — `arena_used_bytes()` went 81692 → 93548 on that model. That is what the
kernel was already writing, but a model that used to fit a tight arena may now
fail to allocate one.

The more memory-efficient alternative — padding all four sides for the `% 16` path,
as conv was fixed in #31 — is not attempted here. Happy to do it as a follow-up.

## Related

Fixes #30. Same class of bug as #31, which fixed `esp_nn_conv_s8_esp32s3`; that one
changed the kernel, this one only changes sizing.

## Testing

ESP32-S3 rev v0.2, `test_app` on IDF v6.0.2: **175 passed, 0 failed**,
`depthwise_conv_s8` speedup 5.46x unchanged. `case 18` covers 49x20x32 with pad
(1,0) and stride 2, as asked in the issue; without the fix it reports

```
[ 18] scratch overflow: wrote at least 11968 bytes past reported size 32944
      [pad: (1, 0), stride: (2, 2), out: ( 25, 10), ch  32]
```

which is exactly 44912 − 32944. End to end against `tf.lite.Interpreter` on the
host, same int8 model and input: max probability delta 0.49219 → 0.00000.

Builds clean for `esp32`, `esp32s3`, `esp32c3`, `esp32p4` and `esp32s31` with the
flags `.gitlab-ci.yml` uses:
https://github.com/dovanviet04112004/esp-nn/actions/runs/32943389721 (workflow on
a separate branch of my fork, not part of this PR).

The test also guards the scratch buffer with a trailing canary. This is
intentional: `scratch_buf` is the last allocation in the loop, so without a guard
an under-allocation can land in unused heap and the regression test may pass on an
unfixed tree. The guard is skipped on targets where
`esp_nn_get_depthwise_conv_scratch_size` returns 0.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.